### PR TITLE
access personal mvn_repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,16 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+    <repositories>
+        <repository>
+            <id>babeloff</id>
+            <url>https://github.com/babeloff/mvn-repo/raw/master/releases</url>
+        </repository>
+        <repository>
+            <id>babeloff-snapshots</id>
+            <url>https://github.com/babeloff/mvn-repo/raw/master/snapshots</url>
+        </repository>
+    </repositories>
     <build>
         <!-- Use non-standard src directory -->
         <sourceDirectory>src</sourceDirectory>
@@ -102,6 +112,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-dependency-plugin</artifactId>
@@ -109,7 +120,7 @@
               <executions>
                 <execution>
                   <id>copy-dependencies</id>
-                  <!-- <phase>package</phase> -->
+                  <phase>package</phase>
                   <goals>
                     <goal>copy-dependencies</goal>
                   </goals>
@@ -122,30 +133,7 @@
                 </execution>
               </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
-                <executions>
-                    <execution>
-                        <id>install-external</id>
-                        <phase>clean</phase>
-                        <configuration>
-                            <file>${project.basedir}/lib/jgraph-5.12.3.2.jar</file>
-                            <repositoryLayout>default</repositoryLayout>
-                            <groupId>jgraph</groupId>
-                            <artifactId>jgraph</artifactId>
-                            <version>5.12.3.2</version>
-                            <packaging>jar</packaging>
-                            <generatePom>true</generatePom>
-                        </configuration>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+            -->
         </plugins>
     </build>
     <dependencies>
@@ -254,7 +242,11 @@
             <version>0.16</version>
         </dependency>
         <!--
-    <dependency><groupId>org.codehaus.jtstand</groupId><artifactId>jtstand-editor</artifactId><version>1.5.13</version></dependency>
+	<dependency>
+            <groupId>org.codehaus.jtstand</groupId>
+            <artifactId>jtstand-editor</artifactId>
+            <version>1.5.13</version>
+        </dependency>
     -->
     </dependencies>
 </project>


### PR DESCRIPTION
Setting up a mirroring mvn-repository [nexus or artifactory] can be burdensome.
Setting up a maven repository using github is very easy.
An example of such a repository is...
https://github.com/babeloff/mvn-repo
This pull-request makes use of that repository for jgraph.
This change would include a fork of mvn-repo into CategoricalData .
