### PR TITLE
Make Maven use latest Eclipse compiler. #117

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,15 +65,23 @@
                     <downloadJavadocs>false</downloadJavadocs>
                 </configuration>
             </plugin>
-            <!-- Set a compiler level -->
+            <!-- Use the Eclipse compiler and set a compiler level -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.2</version>
                 <configuration>
+                    <compilerId>eclipse</compilerId>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-compiler-eclipse</artifactId>
+                        <version>2.8.3</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <!-- Generate the jar manifest -->
             <plugin>


### PR DESCRIPTION
This is a fix towards #117 which get rid of the deluge of type inference errors due to the wrong compiler being used. However, three errors remain:
```
[ERROR] /Users/erik/dev/3rdparty/fql/src/catdata/fpql/XExp.java:[1117] Unlikely argument type for equals(): List<Pair<List<Object>,List<Object>>> seems to be unrelated to XExp.XBool
[ERROR] /Users/erik/dev/3rdparty/fql/src/catdata/opl/OplQuery.java:[178] Unlikely argument type for equals(): S2 seems to be unrelated to S1
[ERROR] /Users/erik/dev/3rdparty/fql/src/catdata/aql/exp/ColimSchExpModify.java:[284] Unlikely argument type for equals(): SchExpRaw.En seems to be unrelated to String
```
@wisnesky Do these errors make sense to you?
@phreed Any thoughts on this patch?
