### PR TITLE
Add unit testing using JUnit, Maven and Surefire. (WIP #121)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,12 @@
                 <directory>resources</directory>
             </resource>
         </resources>
+        <testSourceDirectory>test/src</testSourceDirectory>
+        <testResources>
+            <testResource>
+                <directory>${basedir}/test/resources</directory>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -134,6 +140,11 @@
               </executions>
             </plugin>
             -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.21.0</version>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
@@ -248,5 +259,12 @@
             <version>1.5.13</version>
         </dependency>
     -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/test/src/catdata/aql/AqlTest.java
+++ b/test/src/catdata/aql/AqlTest.java
@@ -1,0 +1,68 @@
+package catdata.aql;
+
+import catdata.Program;
+import catdata.Util;
+import catdata.aql.exp.AqlParser;
+import catdata.aql.exp.AqlEnv;
+import catdata.aql.exp.AqlMultiDriver;
+import catdata.aql.exp.Exp;
+import catdata.ide.Example;
+import catdata.ide.Examples;
+import catdata.ide.Language;
+import java.io.FileReader;
+import java.io.File;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class AqlTest {
+
+    // This duplicated some of AqlTester, but as headless unit tests.
+    @Test
+    public void testAqlExamples() {
+        for (Example e : Examples.getExamples(Language.AQL)) {
+            System.out.println("testing example: " + e.getName());
+            testSourceText("example: " + e.getName(), e.getText());
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////
+    //
+    // helpers
+    //
+    /////////////////////////////////////////////////////////////////////////////////
+
+    public void testSourceText(String description, String src) {
+        try {
+            Program<Exp<?>> prog = AqlParser.getParser().parseProgram(src);
+            testAqlMultiDriver(prog);
+        } catch (Exception e) {
+            fail("Test failed for test case '" + description + "'.");
+            // e.printStackTrace();
+            System.out.println("Test failed for test case '" + description + "'.\n" + e.getStackTrace());
+            fail("Test failed for test case '" + description + "'.\n" + e.getStackTrace());
+        }
+    }
+
+    // TODO Code is similar to that in AqlTester and AqlCmdLine; refactor.
+    public Program<Exp<?>> parseFileOrNull(String fileName) {
+        try (FileReader r = new FileReader(fileName)) {
+            String src = Util.readFile(r);
+            Program<Exp<?>> prog = AqlParser.getParser().parseProgram(src);
+            return prog;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    // TODO Code is similar to that in AqlTester and AqlCmdLine; refactor.
+    public void testAqlMultiDriver(Program<Exp<?>> prog) {
+        AqlMultiDriver driver = new AqlMultiDriver(prog, new String[1], null);
+        driver.start();
+        AqlEnv lastEnv = driver.env;
+        if (lastEnv.exn != null) {
+            throw lastEnv.exn;
+        }
+    }
+}


### PR DESCRIPTION
This is a work in progress; I am making a PR so people can comment on this.

The tests currently run the AQL `Examples` suite, much like `AqlTester` does. Run them using ```mvn test```. Detailed logs should end up in the directory `target/surefire-reports`. (This probably deserves a mention in the readme.)

The tests, when run, show some failures when processing the examples.

NB: The PR as it is now doesn't actually work for me. I cannot run the tests, because of issue #117. I have submitted a tentative PR #118, but that is not ready for merging; see the discussion under both. However, I have tested this with a combination of both this PR and #118, and that allows me to run the tests as described above. From what I gather from the discussion under #117 and #118, it may be that @phreed *will* be able to run the test, as the Maven build seems to be working for him. (Any comments on that would be very much appreciated! :))